### PR TITLE
add non-dotted venv to gitignore

### DIFF
--- a/lib/christmas/py/.gitignore
+++ b/lib/christmas/py/.gitignore
@@ -1,2 +1,3 @@
 .venv
 __pycache__
+venv/


### PR DESCRIPTION
This patch adds `venv` as an additional gitignore target alongside `.venv` to accomodate for development environments that require the virtualenvironment at `venv`.

Signed-off-by: Amy Parker <amy@amyip.net>